### PR TITLE
Add brand.yml theming via bslib

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
             any::lintr
             any::shiny
             any::bslib
+            any::brand.yml
             any::dplyr
             any::ggplot2
             any::DT
@@ -65,6 +66,7 @@ jobs:
           packages: |
             any::shiny
             any::bslib
+            any::brand.yml
             any::dplyr
             any::ggplot2
             any::DT

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ renv::restore()
 install.packages(c(
   "shiny",
   "bslib",
+  "brand.yml",
   "dplyr",
   "ggplot2",
   "DT",
@@ -68,6 +69,7 @@ This template expects a project-level `renv.lock` file and `renv/` metadata to b
 
 ```txt
 .
+├── _brand.yml              # Brand colors, fonts, logo (theming)
 ├── global.R                # Libraries and global objects
 ├── ui.R                    # App UI definition
 ├── server.R                # App server logic
@@ -88,6 +90,15 @@ Recommended deployment paths:
 - Docker image deployment when you want a containerized release
 
 CI/CD-driven publishing is not included here by default unless you explicitly add and maintain it for a given app.
+
+## Theming
+
+Branding lives in [`_brand.yml`](_brand.yml) — colors, fonts, and logo in one
+place. It is applied automatically by bslib via `bs_theme(brand = TRUE)` in
+[ui.R](ui.R). Edit `_brand.yml` to restyle the whole app; no other changes are
+needed. To also theme plots and tables, install
+[`thematic`](https://rstudio.github.io/thematic/) — `global.R` picks it up
+automatically when present. See [docs/theming.md](docs/theming.md).
 
 ## Contributing
 

--- a/_brand.yml
+++ b/_brand.yml
@@ -1,0 +1,27 @@
+# Brand configuration: the app's colors, fonts, and logo in one place.
+# Consumed automatically by bslib via `bs_theme(brand = TRUE)` (see ui.R).
+# Edit these values to match your brand. Spec: https://posit-dev.github.io/brand-yml/
+
+meta:
+  name: My App
+
+color:
+  palette:
+    blue: "#0066cc"
+    gray: "#5b6770"
+  primary: blue
+  secondary: gray
+  foreground: "#1a1a1a"
+  background: "#ffffff"
+
+typography:
+  fonts:
+    - family: Inter
+      source: google
+      weight: [400, 500, 600, 700]
+  base:
+    family: Inter
+    size: 16px
+  headings:
+    family: Inter
+    weight: 600

--- a/dev/init-renv.R
+++ b/dev/init-renv.R
@@ -10,7 +10,15 @@ if (!file.exists("renv.lock")) {
   message("Initializing renv and taking initial snapshot...")
   renv::init(bare = TRUE)
   # Install a few recommended packages used by the template
-  renv::install(c("shiny", "bslib", "dplyr", "ggplot2", "DT", "plotly"))
+  renv::install(c(
+    "shiny",
+    "bslib",
+    "brand.yml",
+    "dplyr",
+    "ggplot2",
+    "DT",
+    "plotly"
+  ))
   renv::snapshot()
   message(
     "renv initialized and renv.lock written. Review renv.lock before committing."

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -40,14 +40,17 @@ Restart the app to see changes. The full set of fields is documented in the
 
 bslib themes the HTML/CSS UI, but R plots are drawn separately. Install
 [`thematic`](https://rstudio.github.io/thematic/) to make base R, ggplot2, and
-lattice graphics inherit the app's colors and fonts automatically:
+lattice graphics inherit the app's colors automatically:
 
 ```r
 install.packages("thematic")
 ```
 
 [global.R](../global.R) already calls `thematic::thematic_shiny(font = "auto")`
-when the package is installed, so no further wiring is required.
+when the package is installed, so no further wiring is required. To also render
+custom or Google fonts (such as Inter) in plots, install
+[`showtext`](https://github.com/yixuan/showtext) — without it, thematic applies
+the theme colors but falls back to the default graphics-device font.
 
 ## Notes
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,56 @@
+# Theming
+
+This template themes the app from a single [`_brand.yml`](../_brand.yml) file
+using the [brand.yml](https://posit-dev.github.io/brand-yml/) standard, applied
+through [bslib](https://rstudio.github.io/bslib/).
+
+## How it works
+
+- `_brand.yml` defines the brand: color palette, semantic colors (primary,
+  secondary, foreground, background), typography (fonts, sizes, weights), and an
+  optional logo.
+- [ui.R](../ui.R) calls `bslib::bs_theme(brand = TRUE)`, which discovers
+  `_brand.yml` at the app root and applies it to the whole UI.
+- `brand = TRUE` requires the file to exist (a clear contract). To make it
+  optional, use `bslib::bs_theme()` instead — it applies `_brand.yml` if found
+  and is a no-op otherwise.
+
+## Customizing
+
+Edit `_brand.yml`. For example, to change the primary color and base font:
+
+```yaml
+color:
+  palette:
+    blue: "#1d4ed8"
+  primary: blue
+
+typography:
+  fonts:
+    - family: Roboto
+      source: google
+      weight: [400, 600]
+  base: Roboto
+```
+
+Restart the app to see changes. The full set of fields is documented in the
+[brand.yml specification](https://posit-dev.github.io/brand-yml/articles/brand-yml.html).
+
+## Theming plots and tables
+
+bslib themes the HTML/CSS UI, but R plots are drawn separately. Install
+[`thematic`](https://rstudio.github.io/thematic/) to make base R, ggplot2, and
+lattice graphics inherit the app's colors and fonts automatically:
+
+```r
+install.packages("thematic")
+```
+
+[global.R](../global.R) already calls `thematic::thematic_shiny(font = "auto")`
+when the package is installed, so no further wiring is required.
+
+## Notes
+
+- `_brand.yml` is app content, not template scaffolding — `dev/use_template.R`
+  keeps it and only updates `meta.name` to your project name.
+- Keep `_brand.yml` in version control so the look of the app is reproducible.

--- a/global.R
+++ b/global.R
@@ -1,5 +1,12 @@
 # Load libraries and source files
 library(shiny)
+library(bslib)
+
+# Optionally theme base/ggplot/lattice output to match the app theme. Activates
+# only if the {thematic} package is installed, so it adds no hard dependency.
+if (requireNamespace("thematic", quietly = TRUE)) {
+  thematic::thematic_shiny(font = "auto")
+}
 
 source("R/load_components.R")
 

--- a/template.yml
+++ b/template.yml
@@ -44,6 +44,9 @@ substitutions:
   - file: ui.R
     from: 'title = "My App"'
     to: 'title = "{{project_name}}"'
+  - file: _brand.yml
+    from: "name: My App"
+    to: "name: {{project_name}}"
   - file: R/utils.R
     from: '"2.0.0"'
     to: '"{{version}}"'

--- a/ui.R
+++ b/ui.R
@@ -1,5 +1,8 @@
 navbarPage(
   title = "My App",
+  # Apply branding from _brand.yml (colors, fonts). brand = TRUE requires the
+  # file to exist; switch to bslib::bs_theme() to make it optional.
+  theme = bslib::bs_theme(brand = TRUE),
   tabPanel("Home", home_page),
   tabPanel("Other", other_page)
 )


### PR DESCRIPTION
## Summary

Adds single-source theming via [brand.yml](https://posit-dev.github.io/brand-yml/), applied through bslib.

- `_brand.yml` — starter brand (colors, Inter font, `meta.name`); one file controls the whole app's look.
- `ui.R` — `navbarPage(theme = bslib::bs_theme(brand = TRUE))`; no migration to `page_navbar` required.
- `global.R` — loads `bslib`; calls `thematic::thematic_shiny()` **only if** `thematic` is installed (optional plot/table theming, no forced dependency).
- Adds the `brand.yml` R package (required by `bs_theme(brand = TRUE)`) to the install lists and both CI jobs.
- `template.yml` now rewrites `_brand.yml`'s `meta.name` during `use_template`.
- Docs: `docs/theming.md` + README Theming section.

## Verification

- UI renders with the brand applied (Inter font loaded, brand colors present).
- All 10 tests pass, including the shinytest2 smoke test, with the theme active.
- `air format --check` clean; lintr 0 lints.

## Type of change

- [x] New feature
- [x] Documentation
