### PR TITLE
Release v2.2: version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to this project should be documented in this file.
 
 ## [Unreleased]
 
-- Initial template setup.
+## [2.2.0] - 2026-06-29
+
+- Added GitHub Actions CI (lint, air format check, tests, markdownlint) and
+  pre-commit hooks.
+- Added air formatter and lintr configuration.
+- Added a test suite (testthat unit tests, `testServer`, and a shinytest2
+  smoke test).
+- Added brand.yml theming applied through bslib, with optional `thematic`
+  plot/table theming.
+- Added a template manifest (`template.yml`) and `dev/use_template.R`
+  scaffolding engine; published the repo as a GitHub template.
+- Added issue and pull request templates and a Contributor Covenant code of
+  conduct.
+- Fixed the app entry point and ensured `R/` utilities are sourced at startup.
 
 ## [0.1.0] - 2026-05-01
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,10 +1,10 @@
 cff-version: 1.1.0
 message: "If you use this software, please cite it as below."
 title: "RShiny Template"
-version: "2.0"
+version: "2.2"
 # doi: set this to your project's DOI (e.g. 10.5281/zenodo.xxxxx)
 doi: "10.5281/zenodo.19968600"
-date-released: "2026-05-02"
+date-released: "2026-06-29"
 authors:
   - family-names: Bharti
     given-names: Samuel

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,5 +7,5 @@ safe_read_rds <- function(path, default = NULL) {
 }
 
 app_version <- function() {
-  "2.0.0"
+  "2.2.0"
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Add a short description of your application.
 
-Current app version: v2.0
+Current app version: v2.2
 
 ## Requirements
 


### PR DESCRIPTION
Bumps version metadata to 2.2 ahead of tagging the v2.2 release.

- CITATION.cff: version 2.2, date-released 2026-06-29
- README: current app version v2.2
- R/utils.R: app_version() -> 2.2.0
- CHANGELOG.md: add [2.2.0] section summarizing this release

## Type of change

- [x] Documentation / maintenance